### PR TITLE
User the backend environment stored in the shared user defaults

### DIFF
--- a/wire-ios-share-engine/SharingSession.swift
+++ b/wire-ios-share-engine/SharingSession.swift
@@ -180,7 +180,7 @@ public class SharingSession {
         userInterfaceContext.zm_sync = syncContext
         syncContext.zm_userInterface = userInterfaceContext
         
-        let environment = ZMBackendEnvironment()
+        let environment = ZMBackendEnvironment(userDefaults: UserDefaults.shared())
         
         let transportSession =  ZMTransportSession(
             baseURL: environment.backendURL,


### PR DESCRIPTION
# What's in this PR?

* The wrong initializer for `ZMBackendEnvironment` has been used, the `init()` will be marked as `NS_UNAVAILBLE` in a PR to `wire-ios-transport` in order to avoid issues like these.