### PR TITLE
Check security level instead of isTrusted property

### DIFF
--- a/wire-ios-share-engine/ZMConversation+Conversation.swift
+++ b/wire-ios-share-engine/ZMConversation+Conversation.swift
@@ -31,7 +31,7 @@ extension ZMConversation: Conversation {
     }
     
     public var isTrusted: Bool {
-        return trusted
+        return securityLevel == .secure
     }
     
     public func appendTextMessage(_ message: String) -> Sendable? {


### PR DESCRIPTION
# What's in this PR?

* Check security level instead of `trusted` property, as there might be participants without any clients.
