### PR TITLE
Fix memory leaks

### DIFF
--- a/wire-ios-share-engine/OperationLoop.swift
+++ b/wire-ios-share-engine/OperationLoop.swift
@@ -123,8 +123,8 @@ final class OperationLoop : NSObject, RequestAvailableObserver {
     typealias ChangeClosure = (_ changed: Set<NSManagedObject>) -> Void
     typealias SaveClosure = (_ notification: Notification, _ insertedObjects: Set<NSManagedObject>, _ updatedObjects: Set<NSManagedObject>) -> Void
 
-    private var syncContext: NSManagedObjectContext
-    private var userContext: NSManagedObjectContext
+    private let syncContext: NSManagedObjectContext
+    private let userContext: NSManagedObjectContext
     private let callBackQueue: OperationQueue
     private var tokens: [NSObjectProtocol] = []
     

--- a/wire-ios-share-engine/OperationLoop.swift
+++ b/wire-ios-share-engine/OperationLoop.swift
@@ -26,6 +26,7 @@ final class RequestGeneratorStore {
     
     let requestGenerators: [ZMTransportRequestGenerator]
     let changeTrackers : [ZMContextChangeTracker]
+    private var isTornDown = false
     
     private let strategies : [AnyObject]
     
@@ -37,7 +38,6 @@ final class RequestGeneratorStore {
         var changeTrackers : [ZMContextChangeTracker] = []
         
         for strategy in strategies {
-            
             if let requestGeneratorSource = strategy as? ZMRequestGeneratorSource {
                 for requestGenerator in requestGeneratorSource.requestGenerators {
                     requestGenerators.append({
@@ -64,12 +64,20 @@ final class RequestGeneratorStore {
         self.requestGenerators = requestGenerators
         self.changeTrackers = changeTrackers
     }
-    
-    var requestGenerator : ZMTransportRequestGenerator {
-        return nextRequest
+
+    deinit {
+        precondition(isTornDown, "Need to call `tearDown` before deallocating this object")
+    }
+
+    func tearDown() {
+        strategies.forEach {
+            $0.tearDown()
+        }
+
+        isTornDown = true
     }
     
-    private func nextRequest() -> ZMTransportRequest? {
+    public func nextRequest() -> ZMTransportRequest? {
         for requestGenerator in requestGenerators {
             if let request = requestGenerator() {
                 return request
@@ -84,19 +92,14 @@ final class RequestGeneratorStore {
 final class RequestGeneratorObserver {
     
     private let context : NSManagedObjectContext
-    private let observedGenerator : ZMTransportRequestGenerator
+    public var observedGenerator: ZMTransportRequestGenerator? = nil
     
-    init(requestGenerator: @escaping ZMTransportRequestGenerator, context: NSManagedObjectContext) {
+    init(context: NSManagedObjectContext) {
         self.context = context
-        self.observedGenerator = requestGenerator
     }
     
-    var requestGenerator : ZMTransportRequestGenerator {
-        return nextRequest
-    }
-    
-    private func nextRequest() -> ZMTransportRequest? {
-        guard let request = observedGenerator() else { return nil }
+    public func nextRequest() -> ZMTransportRequest? {
+        guard let request = observedGenerator?() else { return nil }
         
         request.add(ZMCompletionHandler(on: context, block: { [weak self] transportResponse in
             self?.context.enqueueDelayedSave(with: transportResponse.dispatchGroup)
@@ -120,8 +123,8 @@ final class OperationLoop : NSObject, RequestAvailableObserver {
     typealias ChangeClosure = (_ changed: Set<NSManagedObject>) -> Void
     typealias SaveClosure = (_ notification: Notification, _ insertedObjects: Set<NSManagedObject>, _ updatedObjects: Set<NSManagedObject>) -> Void
 
-    private let syncContext: NSManagedObjectContext
-    private let userContext: NSManagedObjectContext
+    private var syncContext: NSManagedObjectContext
+    private var userContext: NSManagedObjectContext
     private let callBackQueue: OperationQueue
     private var tokens: [NSObjectProtocol] = []
     
@@ -137,8 +140,12 @@ final class OperationLoop : NSObject, RequestAvailableObserver {
         
         RequestAvailableNotification.addObserver(self)
         
-        tokens.append(setupObserver(for: userContext, onSave: userInterfaceContextDidSave))
-        tokens.append(setupObserver(for: syncContext, onSave: syncContextDidSave))
+        tokens.append(setupObserver(for: userContext) { [weak self] (note, inserted, updated) in
+            self?.userInterfaceContextDidSave(notification: note, insertedObjects: inserted, updatedObjects: updated)
+        })
+        tokens.append(setupObserver(for: syncContext) { [weak self] (note, inserted, updated) in
+            self?.syncContextDidSave(notification: note, insertedObjects: inserted, updatedObjects: updated)
+        })
     }
 
     deinit {
@@ -195,35 +202,39 @@ final class RequestGeneratingOperationLoop {
     private let callBackQueue: OperationQueue
     
     private let requestGeneratorStore: RequestGeneratorStore
-    private let requestGeneratorObserver : RequestGeneratorObserver
+    private let requestGeneratorObserver: RequestGeneratorObserver
     private let transportSession: ZMTransportSession
     
 
     init(userContext: NSManagedObjectContext, syncContext: NSManagedObjectContext, callBackQueue: OperationQueue = .main, requestGeneratorStore: RequestGeneratorStore, transportSession: ZMTransportSession) {
         self.callBackQueue = callBackQueue
         self.requestGeneratorStore = requestGeneratorStore
-        self.requestGeneratorObserver = RequestGeneratorObserver(requestGenerator: requestGeneratorStore.requestGenerator, context: syncContext)
+        self.requestGeneratorObserver = RequestGeneratorObserver(context: syncContext)
         self.transportSession = transportSession
         self.operationLoop = OperationLoop(userContext: userContext, syncContext: syncContext, callBackQueue: callBackQueue)
-        operationLoop.changeClosure = objectsDidChange
-        operationLoop.requestAvailableClosure = enqueueRequests
+
+        operationLoop.changeClosure =  { [weak self] changes in self?.objectsDidChange(changes: changes) }
+        operationLoop.requestAvailableClosure = { [weak self] in self?.enqueueRequests() }
+        requestGeneratorObserver.observedGenerator = { [weak self] in self?.requestGeneratorStore.nextRequest() }
     }
 
     fileprivate func objectsDidChange(changes: Set<NSManagedObject>) {
-        
         requestGeneratorStore.changeTrackers.forEach {
             $0.objectsDidChange(changes)
         }
         
         enqueueRequests()
     }
+
+    deinit {
+        requestGeneratorStore.tearDown()
+    }
     
     fileprivate func enqueueRequests() {
-        
         var result : ZMTransportEnqueueResult
         
         repeat {
-            result = transportSession.attemptToEnqueueSyncRequest(generator: requestGeneratorObserver.requestGenerator)
+            result = transportSession.attemptToEnqueueSyncRequest(generator: { [weak self] in self?.requestGeneratorObserver.nextRequest() })
         } while result.didGenerateNonNullRequest && result.didHaveLessRequestThanMax
         
     }

--- a/wire-ios-share-engine/Sendable.swift
+++ b/wire-ios-share-engine/Sendable.swift
@@ -42,7 +42,7 @@ public protocol Sendable {
 }
 
 /// An observer of the progress of a Sendable
-public protocol SendableObserver {
+public protocol SendableObserver: class {
     
     /// Either the delivery state or the delivery progress changed
     func onDeliveryChanged()

--- a/wire-ios-share-engine/SharingSession.swift
+++ b/wire-ios-share-engine/SharingSession.swift
@@ -196,8 +196,13 @@ public class SharingSession {
             sharedContainerIdentifier: applicationGroupIdentifier
         )
         
-        try self.init(userInterfaceContext: userInterfaceContext, syncContext: syncContext, transportSession: transportSession, sharedContainerURL: sharedContainerURL)
-        
+        try self.init(
+            userInterfaceContext: userInterfaceContext,
+            syncContext: syncContext,
+            transportSession: transportSession,
+            sharedContainerURL: sharedContainerURL
+        )
+
     }
     
     internal init(userInterfaceContext: NSManagedObjectContext,
@@ -268,6 +273,8 @@ public class SharingSession {
             NotificationCenter.default.removeObserver(token)
             contextSaveObserverToken = nil
         }
+
+        transportSession.tearDown()
     }
     
     private func setupCaches(atContainerURL containerURL: URL) {

--- a/wire-ios-share-engine/ZMMessage+Sendable.swift
+++ b/wire-ios-share-engine/ZMMessage+Sendable.swift
@@ -46,8 +46,8 @@ extension ZMMessage: Sendable {
     
     public func registerObserverToken(_ observer: SendableObserver) -> SendableObserverToken {
         
-        let token = NotificationCenter.default.addObserver(forName: .NSManagedObjectContextDidSave, object: managedObjectContext?.zm_sync, queue: .main) { (notification) in
-            
+        let token = NotificationCenter.default.addObserver(forName: .NSManagedObjectContextDidSave, object: managedObjectContext?.zm_sync, queue: .main) { [weak observer, weak self] (notification) in
+            guard let `self` = self else { return }
             let updatedObjects  = notification.userInfo?[NSUpdatedObjectsKey]  as? Set<NSManagedObject> ?? Set()
             let insertedObjects = notification.userInfo?[NSInsertedObjectsKey] as? Set<NSManagedObject> ?? Set()
             let deletedObjects  = notification.userInfo?[NSDeletedObjectsKey]  as? Set<NSManagedObject> ?? Set()
@@ -59,7 +59,7 @@ extension ZMMessage: Sendable {
             }
             
             if changedObjects.flatMap({ $0.objectID }).contains(self.objectID) {
-                observer.onDeliveryChanged()
+                observer?.onDeliveryChanged()
             }
         }
         


### PR DESCRIPTION
# What's in this PR?

* Using the shorthand function pointer syntax to assign to a closure can lead to a leak in case self is accessed in the assigned function, as we used this syntactic sugar a lot in the share engine a lot of places had to be modified.
* Insert missing calls to tear down the strategies and the transport session.