### PR TITLE
Simplify observation of changes

### DIFF
--- a/wire-ios-share-engine.xcodeproj/project.pbxproj
+++ b/wire-ios-share-engine.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		543972AD1E3154BA00A02C5F /* SendableBatchObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 543972AC1E3154B900A02C5F /* SendableBatchObserver.swift */; };
 		5470D3EC1D76E1B000FDE440 /* WireShareEngine.h in Headers */ = {isa = PBXBuildFile; fileRef = 5470D3EB1D76E1B000FDE440 /* WireShareEngine.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5470D3F31D76E1B000FDE440 /* WireShareEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5470D3E81D76E1B000FDE440 /* WireShareEngine.framework */; };
 		5470D4301D77154200FDE440 /* SharingSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5470D42F1D77154200FDE440 /* SharingSession.swift */; };
@@ -100,6 +101,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		543972AC1E3154B900A02C5F /* SendableBatchObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SendableBatchObserver.swift; sourceTree = "<group>"; };
 		5470D3E81D76E1B000FDE440 /* WireShareEngine.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WireShareEngine.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5470D3EB1D76E1B000FDE440 /* WireShareEngine.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WireShareEngine.h; sourceTree = "<group>"; };
 		5470D3ED1D76E1B000FDE440 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = "wire-ios-share-engine/Info.plist"; sourceTree = "<group>"; };
@@ -240,6 +242,7 @@
 				5470D4621D7722A500FDE440 /* Sendable.swift */,
 				BF9F130A1DC1052100700255 /* OperationLoop.swift */,
 				BFE7F7521D7885ED00FEA685 /* ZMMessage+Sendable.swift */,
+				543972AC1E3154B900A02C5F /* SendableBatchObserver.swift */,
 			);
 			path = "wire-ios-share-engine";
 			sourceTree = "<group>";
@@ -469,6 +472,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BFE7F7551D7885FF00FEA685 /* ZMConversation+Conversation.swift in Sources */,
+				543972AD1E3154BA00A02C5F /* SendableBatchObserver.swift in Sources */,
 				BF9F130B1DC1052100700255 /* OperationLoop.swift in Sources */,
 				BFE7F7511D78820700FEA685 /* AuthenticationStatusProvider.swift in Sources */,
 				5470D4301D77154200FDE440 /* SharingSession.swift in Sources */,

--- a/wire-ios-share-engine/Sendable.swift
+++ b/wire-ios-share-engine/Sendable.swift
@@ -33,29 +33,6 @@ public protocol Sendable {
     /// It will be 1 when the delivery is completed.
     var deliveryProgress : Float? { get }
     
-    /// Adds an observer for a change in status or delivery progress
-    /// - returns: the observable token
-    func registerObserverToken(_ observer: SendableObserver) -> SendableObserverToken
-    
-    /// Removes an observer token
-    func remove(_ observerToken: SendableObserverToken)
-    
     /// Expire message sending
     func cancel()
-    
-    /// Resend ignoring missing clients
-    func resendIgnoringMissingClients()
-}
-
-/// An observer of the progress of a Sendable
-public protocol SendableObserver: class {
-    
-    /// Either the delivery state or the delivery progress changed
-    func onDeliveryChanged()
-    
-}
-
-/// Wrapper around an observer token for SendableObserver
-public struct SendableObserverToken {
-    let token : AnyObject
 }

--- a/wire-ios-share-engine/SendableBatchObserver.swift
+++ b/wire-ios-share-engine/SendableBatchObserver.swift
@@ -1,0 +1,82 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireShareEngine
+
+
+public final class SendableBatchObserver {
+    
+    public let sendables: [Sendable]
+    
+    public var sentHandler: (() -> Void)?
+    public var progressHandler: ((Float) -> Void)?
+    private var observerToken : Any?
+    
+    
+    
+    public init(sendables: [Sendable]) {
+        self.sendables = sendables
+        self.observerToken = NotificationCenter.default.addObserver(forName: contextWasMergedNotification,
+                                                                    object: nil,
+                                                                    queue: nil) { _ in
+            DispatchQueue.main.async { [weak self] _ in
+                self?.onDeliveryChanged()
+            }
+        }
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self.observerToken)
+    }
+    
+    public var allSendablesSent: Bool {
+        return sendables.first { sendable -> Bool in
+            return sendable.deliveryState != .sent
+                && sendable.deliveryState != .delivered
+            } == nil
+    }
+    
+    public func onDeliveryChanged() {
+        if allSendablesSent {
+            DispatchQueue.main.async { [weak self] in
+                self?.sentHandler?()
+            }
+        }
+        
+        updateProgress()
+    }
+    
+    private func updateProgress() {
+        var totalProgress: Float = 0
+        
+        sendables.forEach { message in
+            if message.deliveryState == .sent || message.deliveryState == .delivered {
+                totalProgress = totalProgress + 1.0 / Float(sendables.count)
+            } else {
+                let messageProgress = (message.deliveryProgress ?? 0)
+                totalProgress = totalProgress +  messageProgress / Float(sendables.count)
+            }
+        }
+        
+        DispatchQueue.main.async { [weak self] in
+            self?.progressHandler?(totalProgress)
+        }
+    }
+    
+}

--- a/wire-ios-share-engine/ZMMessage+Sendable.swift
+++ b/wire-ios-share-engine/ZMMessage+Sendable.swift
@@ -50,34 +50,7 @@ extension ZMMessage: Sendable {
         
         return nil
     }
-    
-    public func registerObserverToken(_ observer: SendableObserver) -> SendableObserverToken {
         
-        let token = NotificationCenter.default.addObserver(forName: contextWasMergedNotification, object: nil, queue: .main) { [weak observer, weak self] (notification) in
-            guard let `self` = self else { return }
-            let updatedObjects  = notification.userInfo?[NSUpdatedObjectsKey]  as? Set<NSManagedObject> ?? Set()
-            let insertedObjects = notification.userInfo?[NSInsertedObjectsKey] as? Set<NSManagedObject> ?? Set()
-            let deletedObjects  = notification.userInfo?[NSDeletedObjectsKey]  as? Set<NSManagedObject> ?? Set()
-            let refreshedObjects = notification.userInfo?[NSRefreshedObjectsKey] as? Set<NSManagedObject> ?? Set()
-            let invalidatedObjects = notification.userInfo?[NSInvalidatedObjectsKey] as? Set<NSManagedObject> ?? Set()
-            
-            let changedObjects = [updatedObjects, insertedObjects, deletedObjects, refreshedObjects, invalidatedObjects].reduce(Set<NSManagedObject>()) {
-                $0.union($1)
-            }
-            
-            if changedObjects.flatMap({ $0.objectID }).contains(self.objectID) {
-                observer?.onDeliveryChanged()
-            }
-        }
-        
-        return SendableObserverToken(token: token)
-    }
-    
-    
-    public func remove(_ observerToken: SendableObserverToken) {
-        NotificationCenter.default.removeObserver(observerToken.token)
-    }
-    
     public func cancel() {
         
         if let asset = self.fileMessageData {
@@ -85,10 +58,6 @@ extension ZMMessage: Sendable {
             return
         }
         self.expire()
-    }
-    
-    public func resendIgnoringMissingClients() {
-        self.resend()
     }
     
 }


### PR DESCRIPTION
# Reason for this pull request
Observing changes on the context was unreliable. This PR uses a safer approach: re-check for changes on EVERY save.