### PR TITLE
Store save info from both contexts

### DIFF
--- a/wire-ios-share-engine/OperationLoop.swift
+++ b/wire-ios-share-engine/OperationLoop.swift
@@ -171,8 +171,8 @@ final class OperationLoop : NSObject, RequestAvailableObserver {
             context.mergeUserInfo(fromUserInfo: userInfo)
             context.mergeChanges(fromContextDidSave: notification)
             context.processPendingChanges() // We need this because merging sometimes leaves the MOC in a 'dirty' state
-            
-            NotificationCenter.default.post(name: contextWasMergedNotification, object: context)
+
+            NotificationCenter.default.post(name: contextWasMergedNotification, object: context, userInfo: notification.userInfo)
         }
     }
     

--- a/wire-ios-share-engine/SharingSession.swift
+++ b/wire-ios-share-engine/SharingSession.swift
@@ -295,8 +295,8 @@ public class SharingSession {
 
     private func setupObservers() {
         contextSaveObserverToken = NotificationCenter.default.addObserver(
-            forName: .NSManagedObjectContextDidSave,
-            object: userInterfaceContext,
+            forName: contextWasMergedNotification,
+            object: nil,
             queue: .main,
             using: saveNotificationPersistence.add
         )


### PR DESCRIPTION
# What's in this PR?

* We were missing the change info from the `syncMOC` and thus were missing updated clients in the main app after discovering them from the share-extension.