### PR TITLE
Extract strategy creation in separate class, add option to fetch link previews

### DIFF
--- a/wire-ios-share-engine.xcodeproj/project.pbxproj
+++ b/wire-ios-share-engine.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		54B04A6B1D77359A00CED57C /* ZMTransport.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5470D4531D77169900FDE440 /* ZMTransport.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		54B04A6C1D77359A00CED57C /* ZMUtilities.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5470D4541D77169900FDE440 /* ZMUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		54B04A6D1D77359A00CED57C /* ZMCDataModel.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5470D4311D77165800FDE440 /* ZMCDataModel.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		BF2009331E3A24A2006F8930 /* StrategyFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF2009321E3A24A2006F8930 /* StrategyFactory.swift */; };
 		BF9F130B1DC1052100700255 /* OperationLoop.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9F130A1DC1052100700255 /* OperationLoop.swift */; };
 		BFA18BD41D806050005C281B /* BaseSharingSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA18BD31D806050005C281B /* BaseSharingSessionTests.swift */; };
 		BFE7F7511D78820700FEA685 /* AuthenticationStatusProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE7F7501D78820700FEA685 /* AuthenticationStatusProvider.swift */; };
@@ -144,6 +145,7 @@
 		5470D4601D771BD600FDE440 /* SharingTarget.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharingTarget.swift; sourceTree = "<group>"; };
 		5470D4621D7722A500FDE440 /* Sendable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sendable.swift; sourceTree = "<group>"; };
 		5470D4641D772A6000FDE440 /* Conversation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Conversation.swift; sourceTree = "<group>"; };
+		BF2009321E3A24A2006F8930 /* StrategyFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StrategyFactory.swift; sourceTree = "<group>"; };
 		BF64A2111D796DC300725918 /* wire-ios-share-engineTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "wire-ios-share-engineTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		BF9F130A1DC1052100700255 /* OperationLoop.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperationLoop.swift; sourceTree = "<group>"; };
 		BFA18BD31D806050005C281B /* BaseSharingSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseSharingSessionTests.swift; sourceTree = "<group>"; };
@@ -235,6 +237,7 @@
 			children = (
 				5470D3EB1D76E1B000FDE440 /* WireShareEngine.h */,
 				5470D42F1D77154200FDE440 /* SharingSession.swift */,
+				BF2009321E3A24A2006F8930 /* StrategyFactory.swift */,
 				5470D4641D772A6000FDE440 /* Conversation.swift */,
 				BFE7F7541D7885FF00FEA685 /* ZMConversation+Conversation.swift */,
 				BFE7F7501D78820700FEA685 /* AuthenticationStatusProvider.swift */,
@@ -480,6 +483,7 @@
 				5470D4611D771BD600FDE440 /* SharingTarget.swift in Sources */,
 				BFE7F7531D7885ED00FEA685 /* ZMMessage+Sendable.swift in Sources */,
 				5470D4651D772A6000FDE440 /* Conversation.swift in Sources */,
+				BF2009331E3A24A2006F8930 /* StrategyFactory.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/wire-ios-share-engine/Sendable.swift
+++ b/wire-ios-share-engine/Sendable.swift
@@ -23,7 +23,7 @@ import ZMCDataModel
 public protocol Sendable {
     
     /// The state of the delivery
-    var deliveryState : ZMDeliveryState { get }
+    var isSent: Bool { get }
 
     /// Whether the sendable is currently blocked because of missing clients
     var blockedBecauseOfMissingClients : Bool { get }

--- a/wire-ios-share-engine/SendableBatchObserver.swift
+++ b/wire-ios-share-engine/SendableBatchObserver.swift
@@ -44,10 +44,7 @@ public final class SendableBatchObserver {
     }
     
     public var allSendablesSent: Bool {
-        let notSent = sendables.first { sendable -> Bool in
-            return sendable.deliveryState != .sent && sendable.deliveryState != .delivered
-        }
-        return notSent == nil
+        return !sendables.contains { !$0.isSent }
     }
     
     public func onDeliveryChanged() {
@@ -64,7 +61,7 @@ public final class SendableBatchObserver {
         var totalProgress: Float = 0
         
         sendables.forEach { message in
-            if message.deliveryState == .sent || message.deliveryState == .delivered {
+            if message.isSent {
                 totalProgress = totalProgress + 1.0 / Float(sendables.count)
             } else {
                 let messageProgress = (message.deliveryProgress ?? 0)

--- a/wire-ios-share-engine/SharingSession.swift
+++ b/wire-ios-share-engine/SharingSession.swift
@@ -233,18 +233,13 @@ public class SharingSession {
         let authenticationStatus = AuthenticationStatus(transportSession: transportSession)
         let clientRegistrationStatus = ClientRegistrationStatus(context: syncContext)
         
-        let clientMessageTranscoder = ZMClientMessageTranscoder(
-            managedObjectContext: syncContext,
-            localNotificationDispatcher: PushMessageHandlerDummy(),
-            clientRegistrationStatus: clientRegistrationStatus,
-            apnsConfirmationStatus: DeliveryConfirmationDummy()
-        )!
-        
-        let missingClientStrategy = MissingClientsRequestStrategy(clientRegistrationStatus: clientRegistrationStatus, apnsConfirmationStatus: DeliveryConfirmationDummy(), managedObjectContext: syncContext)
-        let imageUploadStrategy = ImageUploadRequestStrategy(clientRegistrationStatus: clientRegistrationStatus, managedObjectContext: syncContext, maxConcurrentImageOperation: 1)
-        let fileUploadStrategy = FileUploadRequestStrategy(clientRegistrationStatus: clientRegistrationStatus, managedObjectContext: syncContext, taskCancellationProvider: transportSession)
+        let strategyFactory = StrategyFactory(
+            syncContext: syncContext,
+            registrationStatus: clientRegistrationStatus,
+            cancellationProvider: transportSession
+        )
 
-        let requestGeneratorStore = RequestGeneratorStore(strategies: [missingClientStrategy, clientMessageTranscoder, imageUploadStrategy, fileUploadStrategy])
+        let requestGeneratorStore = RequestGeneratorStore(strategies: strategyFactory.createStrategies())
 
         let operationLoop = RequestGeneratingOperationLoop(
             userContext: userInterfaceContext,

--- a/wire-ios-share-engine/SharingTarget.swift
+++ b/wire-ios-share-engine/SharingTarget.swift
@@ -23,7 +23,7 @@ import ZMCDataModel
 public protocol SharingTarget {
     
     /// Appends a text message in the conversation
-    func appendTextMessage(_ message: String) -> Sendable?
+    func appendTextMessage(_ message: String, fetchLinkPreview: Bool) -> Sendable?
     
     /// Appends an image in the conversation
     func appendImage(_ image: URL) -> Sendable?

--- a/wire-ios-share-engine/StrategyFactory.swift
+++ b/wire-ios-share-engine/StrategyFactory.swift
@@ -1,0 +1,84 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+import WireMessageStrategy
+import ZMTransport.ZMRequestCancellation
+
+
+class StrategyFactory {
+
+    let syncContext: NSManagedObjectContext
+    let registrationStatus: ClientRegistrationStatus
+    let cancellationProvider: ZMRequestCancellation
+
+    init(syncContext: NSManagedObjectContext, registrationStatus: ClientRegistrationStatus, cancellationProvider: ZMRequestCancellation) {
+        self.syncContext = syncContext
+        self.registrationStatus = registrationStatus
+        self.cancellationProvider = cancellationProvider
+    }
+
+    func createStrategies() -> [AnyObject] {
+        return [
+            createMissingClientsStrategy(),
+            createClientMessageTranscoder(),
+            createImageUploadRequestStrategy(),
+            createFileUploadRequestStrategy(),
+            createLinkPreviewAssetUploadRequestStrategy()
+        ]
+    }
+
+    private func createMissingClientsStrategy() -> MissingClientsRequestStrategy {
+        return MissingClientsRequestStrategy(
+            clientRegistrationStatus: registrationStatus,
+            apnsConfirmationStatus: DeliveryConfirmationDummy(),
+            managedObjectContext: syncContext
+        )
+    }
+
+    private func createClientMessageTranscoder() -> ZMClientMessageTranscoder {
+        return ZMClientMessageTranscoder(
+            managedObjectContext: syncContext,
+            localNotificationDispatcher: PushMessageHandlerDummy(),
+            clientRegistrationStatus: registrationStatus,
+            apnsConfirmationStatus: DeliveryConfirmationDummy()
+        )!
+    }
+
+    private func createImageUploadRequestStrategy() -> ImageUploadRequestStrategy {
+        return ImageUploadRequestStrategy(
+            clientRegistrationStatus: registrationStatus,
+            managedObjectContext: syncContext,
+            maxConcurrentImageOperation: 1
+        )
+    }
+
+    private func createFileUploadRequestStrategy() -> FileUploadRequestStrategy {
+        return FileUploadRequestStrategy(
+            clientRegistrationStatus: registrationStatus,
+            managedObjectContext: syncContext,
+            taskCancellationProvider: cancellationProvider
+        )
+    }
+
+    private func createLinkPreviewAssetUploadRequestStrategy() -> LinkPreviewAssetUploadRequestStrategy {
+        return LinkPreviewAssetUploadRequestStrategy(clientRegistrationDelegate: registrationStatus, managedObjectContext: syncContext)
+    }
+
+}

--- a/wire-ios-share-engine/ZMConversation+Conversation.swift
+++ b/wire-ios-share-engine/ZMConversation+Conversation.swift
@@ -34,8 +34,8 @@ extension ZMConversation: Conversation {
         return securityLevel == .secure
     }
     
-    public func appendTextMessage(_ message: String) -> Sendable? {
-        return appendMessage(withText: message, fetchLinkPreview: false) as? Sendable
+    public func appendTextMessage(_ message: String, fetchLinkPreview: Bool) -> Sendable? {
+        return appendMessage(withText: message, fetchLinkPreview: fetchLinkPreview) as? Sendable
     }
     
     public func appendImage(_ url: URL) -> Sendable? {

--- a/wire-ios-share-engine/ZMMessage+Sendable.swift
+++ b/wire-ios-share-engine/ZMMessage+Sendable.swift
@@ -42,6 +42,18 @@ extension ZMMessage: Sendable {
         }
         return self.deliveryState == .failedToSend && message.causedSecurityLevelDegradation
     }
+
+    public var isSent: Bool {
+        if let clientMessage = self as? ZMClientMessage {
+            return clientMessage.linkPreviewState == .done && sentOrDelivered
+        } else {
+            return sentOrDelivered
+        }
+    }
+
+    private var sentOrDelivered: Bool {
+        return deliveryState == .sent || deliveryState == .delivered
+    }
     
     public var deliveryProgress: Float? {
         if let asset = self as? ZMAssetClientMessage, reportsProgress {


### PR DESCRIPTION
# What's in this PR?

* Extract the creation of all strategies used in the share extension into a separate class called `StrategyFactory`.
* Add the `LinkPreviewAssetUploadRequestStrategy` to the included strategies.
* Change the `appendTextMessage` method to take an additional parameter specifying if a link preview should be fetched.
* Modify and rename the `deliveryState` property to `isSent`, it now also checks the `linkPreviewState` in the case of a `ZMClientMessage` to avoid the share extension being deallocated before the link preview has been fetched an uploaded.