### PR TITLE
Only consider asset client message as sent when uploadState is done

### DIFF
--- a/wire-ios-share-engine/ZMMessage+Sendable.swift
+++ b/wire-ios-share-engine/ZMMessage+Sendable.swift
@@ -41,10 +41,16 @@ extension ZMMessage: Sendable {
 
     public var isSent: Bool {
         if let clientMessage = self as? ZMClientMessage {
-            return clientMessage.linkPreviewState == .done && sentOrDelivered
-        } else {
-            return sentOrDelivered
+            if clientMessage.linkPreviewState != .done {
+                return false
+            }
+        } else if let assetMessage = self as? ZMAssetClientMessage {
+            if assetMessage.uploadState != .done {
+                return false
+            }
         }
+
+        return sentOrDelivered
     }
 
     private var sentOrDelivered: Bool {


### PR DESCRIPTION
# What's in this PR?

* Image messages are marked as sent after the response for the preview upload has been received, which leads to the share extension being dismissed prematurely and sporadic failures sending the medium image (depending on the size of the image and the number of clients it is being sent to).