### PR TITLE
Only tear down strategies if they respond to the selector

### DIFF
--- a/Sources/OperationLoop.swift
+++ b/Sources/OperationLoop.swift
@@ -74,7 +74,9 @@ final class RequestGeneratorStore {
 
     func tearDown() {
         strategies.forEach {
-            $0.tearDown()
+            if $0.responds(to: #selector(ZMObjectSyncStrategy.tearDown)) {
+                ($0 as? ZMObjectSyncStrategy)?.tearDown()
+            }
         }
 
         isTornDown = true

--- a/wire-ios-share-engineTests/BaseSharingSessionTests.swift
+++ b/wire-ios-share-engineTests/BaseSharingSessionTests.swift
@@ -87,4 +87,11 @@ class BaseSharingSessionTests: ZMTBaseTest {
         moc = sharingSession.userInterfaceContext
     }
 
+    override func tearDown() {
+        sharingSession = nil
+        authenticationStatus = nil
+        moc = nil
+        super.tearDown()
+    }
+
 }


### PR DESCRIPTION
# What's in this PR?

* Fix a crash happening when trying to call `tearDown` on `MissingClientsRequestStrategy`.