### PR TITLE
Remove shared container identifier transport session

### DIFF
--- a/Sources/SharingSession.swift
+++ b/Sources/SharingSession.swift
@@ -266,7 +266,7 @@ public class SharingSession {
             cookieStorage: cookieStorage,
             reachability: reachability,
             initialAccessToken: ZMAccessToken(),
-            sharedContainerIdentifier: applicationGroupIdentifier
+            sharedContainerIdentifier: nil
         )
         
         try self.init(


### PR DESCRIPTION
### Problem:
Share extension creates a file in the caches directory which makes the main app throw an error.

### Solution:
Doesn't create transport session configured for background requests.

The shared container identifier is used in the transport session for background requests
managed by the system. The system will then wake the app up when the request finishes but
we don't use this functionallity at the moment.