### PR TITLE
Tear down the transport to avoid the crash

### DIFF
--- a/Sources/OperationLoop.swift
+++ b/Sources/OperationLoop.swift
@@ -237,6 +237,7 @@ final class RequestGeneratingOperationLoop {
     }
 
     deinit {
+        transportSession.tearDown()
         requestGeneratorStore.tearDown()
     }
     


### PR DESCRIPTION
- Teardown is mandatory on reachability object that is the part of the transport. This causes the crash on dealloc.