### PR TITLE
Added the flag "isLocalAuthenticationGranted"

### DIFF
--- a/Sources/SharingSession.swift
+++ b/Sources/SharingSession.swift
@@ -205,7 +205,8 @@ public class SharingSession {
         return applicationStatusDirectory.authenticationStatus.state == .authenticated && applicationStatusDirectory.clientRegistrationStatus.clientIsReadyForRequests
     }
     
-    /// Flag to remember if the user authenticated through LocalAuthentication
+    /// To check if the user has already authenticated through LocalAuthentication
+    /// during the current session.
     public var isAuthenticated : Bool = false
 
     /// List of non-archived conversations in which the user can write

--- a/Sources/SharingSession.swift
+++ b/Sources/SharingSession.swift
@@ -204,6 +204,9 @@ public class SharingSession {
     public var canShare: Bool {
         return applicationStatusDirectory.authenticationStatus.state == .authenticated && applicationStatusDirectory.clientRegistrationStatus.clientIsReadyForRequests
     }
+    
+    /// Flag to remember if the user authenticated through LocalAuthentication
+    public var isAuthenticated : Bool = false
 
     /// List of non-archived conversations in which the user can write
     /// The list will be sorted by relevance

--- a/Sources/SharingSession.swift
+++ b/Sources/SharingSession.swift
@@ -207,7 +207,7 @@ public class SharingSession {
     
     /// To check if the user has already authenticated through LocalAuthentication
     /// during the current session.
-    public var isAuthenticated : Bool = false
+    public var isLocalAuthenticationGranted : Bool = false
 
     /// List of non-archived conversations in which the user can write
     /// The list will be sorted by relevance


### PR DESCRIPTION
## What's new in this PR?

I added the `isLocalAuthenticationGranted` flag to `SharingSession`, in order to remember if the user was already authenticated via `LocalAuthentication` during the current session. 

## Dependencies

Needs releases with:

- [ ] https://github.com/wireapp/wire-ios/pull/1436
