### PR TITLE
Do not tear down the storage stack in sharing session

### DIFF
--- a/Sources/SharingSession.swift
+++ b/Sources/SharingSession.swift
@@ -346,7 +346,6 @@ public class SharingSession {
         transportSession.reachability.tearDown()
         transportSession.tearDown()
         strategyFactory.tearDown()
-        StorageStack.reset()
     }
     
     private func setupCaches(at cachesDirectory: URL) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

The `SharingSession` is re-created in share extension when user is selecting the other account.

`tearDown()` method of `SharingSession` was calling `StorageStack.reset()`.

The implementation of `StorageStack.reset()` has changed in the way that it is turning down the managed object context directory: `StorageStack.currentStack?.managedObjectContextDirectory?.tearDown()`.

Generally, the storage stack must not be torn down when switching the accounts, so now we are going to call `StorageStack.reset()` when the share extension is torn down.