### PR TITLE
Replace build badge with Azure Pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Wire logo](https://github.com/wireapp/wire/blob/master/assets/header-small.png?raw=true)](https://wire.com/jobs/)
 
-[![CircleCI](https://circleci.com/gh/wireapp/wire-ios-share-engine.svg?style=shield)](https://circleci.com/gh/wireapp/wire-ios-share-engine) [![codecov](https://codecov.io/gh/wireapp/wire-ios-share-engine/branch/develop/graph/badge.svg)](https://codecov.io/gh/wireapp/wire-ios-share-engine)
+[![Azure Pipelines Build Status](https://dev.azure.com/wireswiss/Wire%20iOS/_apis/build/status/Frameworks/wire-ios-share-engine?branchName=develop)](https://dev.azure.com/wireswiss/Wire%20iOS/_build/latest?definitionId=18&branchName=develop) [![codecov](https://codecov.io/gh/wireapp/wire-ios-share-engine/branch/develop/graph/badge.svg)](https://codecov.io/gh/wireapp/wire-ios-share-engine)
 
 This repository is part of the source code of Wire. You can find more information at [wire.com](https://wire.com) or by contacting opensource@wire.com.
 


### PR DESCRIPTION
Since you no longer have a .circleci/config.yml, I updated the build badge to use the Azure Pipelines build. Not sure if you want to scope this to a particular branch, but I scoped it to `develop`.