### PR TITLE
Added a way to check if account is authenticated

### DIFF
--- a/Sources/SharingSession.swift
+++ b/Sources/SharingSession.swift
@@ -98,6 +98,17 @@ class AuthenticationStatus : AuthenticationStatusProvider {
     
 }
 
+extension BackendEnvironmentProvider {
+    func cookieStorage(for account: Account) -> ZMPersistentCookieStorage {
+        let backendURL = self.backendURL.host!
+        return ZMPersistentCookieStorage(forServerName: backendURL, userIdentifier: account.userIdentifier)
+    }
+    
+    public func isAuthenticated(_ account: Account) -> Bool {
+        return cookieStorage(for: account).authenticationCookieData != nil
+    }
+}
+
 class ApplicationStatusDirectory : ApplicationStatus {
 
     let transportSession : ZMTransportSession


### PR DESCRIPTION
## What's new in this PR?

### Issues

From inside share extension we need a method to check if account has existing cookie and is authenticated.

### Solutions

Added identical method that is available in SyncEngine.
