### PR TITLE
Expose the security level of the conversation

### DIFF
--- a/Sources/Conversation.swift
+++ b/Sources/Conversation.swift
@@ -30,7 +30,7 @@ public protocol Conversation : SharingTarget {
     var conversationType : ZMConversationType { get }
     
     /// Returns true if the conversation is trusted (all participants are trusted)
-    var isTrusted : Bool { get }
+    var securityLevel : ZMConversationSecurityLevel { get }
 
     /// The status of legal hold in the conversation.
     var legalHoldStatus: ZMConversationLegalHoldStatus { get }

--- a/Sources/ZMConversation+Conversation.swift
+++ b/Sources/ZMConversation+Conversation.swift
@@ -25,11 +25,7 @@ import WireRequestStrategy
 extension ZMConversation: Conversation {
 
     @objc public var name: String { return displayName }
-    
-    @objc public var isTrusted: Bool {
-        return securityLevel == .secure
-    }
-    
+        
     public func appendTextMessage(_ message: String, fetchLinkPreview: Bool) -> Sendable? {
         return append(text: message, fetchLinkPreview: fetchLinkPreview) as? Sendable
     }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We need to expose the security level of the conversation in order to display the correct verified shield.