### PR TITLE
[Feature] Add support for EAR in the SharingSession

### DIFF
--- a/Sources/SharingSession+EncryptionAtRest.swift
+++ b/Sources/SharingSession+EncryptionAtRest.swift
@@ -1,0 +1,49 @@
+//
+// Wire
+// Copyright (C) 2020 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireDataModel
+import LocalAuthentication
+
+public protocol SharingSessionEncryptionAtRestInterface {
+    var encryptMessagesAtRest: Bool { get }
+    var isDatabaseLocked: Bool { get }
+    func unlockDatabase(with context: LAContext) throws
+}
+
+extension SharingSession: SharingSessionEncryptionAtRestInterface {
+    
+    public var encryptMessagesAtRest: Bool {
+        get {
+            return  userInterfaceContext.encryptMessagesAtRest
+        }
+    }
+    
+    public var isDatabaseLocked: Bool {
+        userInterfaceContext.encryptMessagesAtRest && userInterfaceContext.encryptionKeys == nil
+    }
+    
+    public func unlockDatabase(with context: LAContext) throws {
+        let userIdentifier = ZMUser.selfUser(in: userInterfaceContext).remoteIdentifier!
+        let account = Account(userName: "", userIdentifier: userIdentifier)
+        let keys = try EncryptionKeys.init(account: account, context: context)
+        
+        contextDirectory.storeEncryptionKeysInAllContexts(encryptionKeys: keys)
+    }
+    
+}

--- a/Sources/SharingSession+EncryptionAtRest.swift
+++ b/Sources/SharingSession+EncryptionAtRest.swift
@@ -29,9 +29,7 @@ public protocol SharingSessionEncryptionAtRestInterface {
 extension SharingSession: SharingSessionEncryptionAtRestInterface {
     
     public var encryptMessagesAtRest: Bool {
-        get {
-            return  userInterfaceContext.encryptMessagesAtRest
-        }
+        return userInterfaceContext.encryptMessagesAtRest
     }
     
     public var isDatabaseLocked: Bool {

--- a/Sources/SharingSession.swift
+++ b/Sources/SharingSession.swift
@@ -172,7 +172,7 @@ public class SharingSession {
 
     let transportSession: ZMTransportSession
     
-    private var contextDirectory: ManagedObjectContextDirectory!
+    var contextDirectory: ManagedObjectContextDirectory!
     
     /// The `ZMConversationListDirectory` containing all conversation lists
     private var directory: ZMConversationListDirectory {

--- a/WireShareEngine.xcodeproj/project.pbxproj
+++ b/WireShareEngine.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		165C55F62551AF1300731CA9 /* SharingSession+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165C55F52551AF1300731CA9 /* SharingSession+EncryptionAtRest.swift */; };
+		166DCD9E2552969B004F4F59 /* SharingSessionTests+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166DCD9D2552969B004F4F59 /* SharingSessionTests+EncryptionAtRest.swift */; };
 		5470D3F31D76E1B000FDE440 /* WireShareEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5470D3E81D76E1B000FDE440 /* WireShareEngine.framework */; };
 		5470D4321D77165800FDE440 /* WireDataModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5470D4311D77165800FDE440 /* WireDataModel.framework */; };
 		5470D4551D77169900FDE440 /* WireCryptobox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5470D44A1D77169900FDE440 /* WireCryptobox.framework */; };
@@ -104,6 +105,7 @@
 
 /* Begin PBXFileReference section */
 		165C55F52551AF1300731CA9 /* SharingSession+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SharingSession+EncryptionAtRest.swift"; sourceTree = "<group>"; };
+		166DCD9D2552969B004F4F59 /* SharingSessionTests+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SharingSessionTests+EncryptionAtRest.swift"; sourceTree = "<group>"; };
 		5470D3E81D76E1B000FDE440 /* WireShareEngine.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WireShareEngine.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5470D3F21D76E1B000FDE440 /* WireShareEngineTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WireShareEngineTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5470D3F91D76E1B000FDE440 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -243,6 +245,7 @@
 				5470D3F91D76E1B000FDE440 /* Info.plist */,
 				BFA18BD31D806050005C281B /* BaseSharingSessionTests.swift */,
 				F125E9B41E28DB06006583A2 /* SharingSessionTests.swift */,
+				166DCD9D2552969B004F4F59 /* SharingSessionTests+EncryptionAtRest.swift */,
 				CEB50AEB1DF9BADF00211B30 /* OperationLoopTests.swift */,
 				CE7FBFC31E015C5900E1C4C9 /* RequestGeneratorStoreTests.swift */,
 			);
@@ -532,6 +535,7 @@
 				CE7FBFC41E015C5900E1C4C9 /* RequestGeneratorStoreTests.swift in Sources */,
 				BFA18BD41D806050005C281B /* BaseSharingSessionTests.swift in Sources */,
 				CEB50AEC1DF9BADF00211B30 /* OperationLoopTests.swift in Sources */,
+				166DCD9E2552969B004F4F59 /* SharingSessionTests+EncryptionAtRest.swift in Sources */,
 				F125E9B51E28DB06006583A2 /* SharingSessionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WireShareEngine.xcodeproj/project.pbxproj
+++ b/WireShareEngine.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		165C55F62551AF1300731CA9 /* SharingSession+EncryptionAtRest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 165C55F52551AF1300731CA9 /* SharingSession+EncryptionAtRest.swift */; };
 		5470D3F31D76E1B000FDE440 /* WireShareEngine.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5470D3E81D76E1B000FDE440 /* WireShareEngine.framework */; };
 		5470D4321D77165800FDE440 /* WireDataModel.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5470D4311D77165800FDE440 /* WireDataModel.framework */; };
 		5470D4551D77169900FDE440 /* WireCryptobox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5470D44A1D77169900FDE440 /* WireCryptobox.framework */; };
@@ -102,6 +103,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		165C55F52551AF1300731CA9 /* SharingSession+EncryptionAtRest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SharingSession+EncryptionAtRest.swift"; sourceTree = "<group>"; };
 		5470D3E81D76E1B000FDE440 /* WireShareEngine.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WireShareEngine.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5470D3F21D76E1B000FDE440 /* WireShareEngineTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WireShareEngineTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5470D3F91D76E1B000FDE440 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -323,6 +325,7 @@
 				F1DABF9A1E9B8B6100AD2324 /* Sendable.swift */,
 				F1DABF9B1E9B8B6100AD2324 /* SendableBatchObserver.swift */,
 				F1DABF9C1E9B8B6100AD2324 /* SharingSession.swift */,
+				165C55F52551AF1300731CA9 /* SharingSession+EncryptionAtRest.swift */,
 				F1DABF9D1E9B8B6100AD2324 /* SharingTarget.swift */,
 				F1DABF9E1E9B8B6100AD2324 /* StrategyFactory.swift */,
 				F1DABF9F1E9B8B6100AD2324 /* WireShareEngine.h */,
@@ -510,6 +513,7 @@
 			files = (
 				F1DABFA31E9B8B6100AD2324 /* Conversation.swift in Sources */,
 				F1DABFAB1E9B8B6100AD2324 /* ZMConversation+Conversation.swift in Sources */,
+				165C55F62551AF1300731CA9 /* SharingSession+EncryptionAtRest.swift in Sources */,
 				F1DABFA21E9B8B6100AD2324 /* AuthenticationStatusProvider.swift in Sources */,
 				F1DABFA41E9B8B6100AD2324 /* OperationLoop.swift in Sources */,
 				F1DABFA91E9B8B6100AD2324 /* StrategyFactory.swift in Sources */,

--- a/WireShareEngineTests/SharingSessionTests+EncryptionAtRest.swift
+++ b/WireShareEngineTests/SharingSessionTests+EncryptionAtRest.swift
@@ -1,0 +1,33 @@
+//
+//  SharingSessionTest+EncryptionAtRest.swift
+//  WireShareEngineTests
+//
+//  Created by Jacob Persson on 04.11.20.
+//  Copyright © 2020 com.wire. All rights reserved.
+//
+
+import XCTest
+
+class SharingSessionTest_EncryptionAtRest: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}


### PR DESCRIPTION
## What's new in this PR?

Expose a public API in the `SharingSession` for encryption at rest. This API will be used by the share extension to ask the user to authenticate if the database is locked.