### PR TITLE
fix: SwiftLint warnings for `type_name`,  `shorthand_operator`, `compiler_protocol_init`, `file_length` & remove a bunch of them from the disabled rules list

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -24,7 +24,6 @@ disabled_rules:
     - nesting
     - function_parameter_count
     - xctfail_message
-    - compiler_protocol_init
     - reduce_boolean
 
 included:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,7 +6,6 @@ disabled_rules:
     - force_cast
     - force_try
     - identifier_name
-    - type_name
     - todo
     - large_tuple
     - unused_setter_value

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,7 +4,6 @@ disabled_rules:
     - generic_type_name
     - force_cast
     - force_try
-    - identifier_name
     - todo
     - large_tuple
     - unused_setter_value

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,28 +1,8 @@
 disabled_rules:
     - function_body_length
-    - type_body_length
-    - generic_type_name
     - force_cast
     - force_try
     - todo
-    - large_tuple
-    - unused_setter_value
-    - notification_center_detachment
-    - discarded_notification_center_observer
-    - cyclomatic_complexity
-    - closure_parameter_position
-    - statement_position
-    - weak_delegate
-    - inclusive_language
-    - class_delegate_protocol
-    - legacy_cggeometry_functions
-    - legacy_constructor
-    - legacy_hashing
-    - multiple_closures_with_trailing_closure
-    - nesting
-    - function_parameter_count
-    - xctfail_message
-    - reduce_boolean
 
 included:
     - Sources

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,7 +26,6 @@ disabled_rules:
     - xctfail_message
     - compiler_protocol_init
     - reduce_boolean
-    - shorthand_operator
 
 included:
     - Sources

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,7 +1,6 @@
 disabled_rules:
     - function_body_length
     - type_body_length
-    - file_length
     - generic_type_name
     - force_cast
     - force_try

--- a/Sources/SendableBatchObserver.swift
+++ b/Sources/SendableBatchObserver.swift
@@ -62,10 +62,10 @@ public final class SendableBatchObserver {
 
         sendables.forEach { message in
             if message.isSent {
-                totalProgress = totalProgress + 1.0 / Float(sendables.count)
+                totalProgress += 1.0 / Float(sendables.count)
             } else {
                 let messageProgress = (message.deliveryProgress ?? 0)
-                totalProgress = totalProgress +  messageProgress / Float(sendables.count)
+                totalProgress += messageProgress / Float(sendables.count)
             }
         }
 

--- a/Sources/SharingSession.swift
+++ b/Sources/SharingSession.swift
@@ -27,7 +27,6 @@ class PushMessageHandlerDummy: NSObject, PushMessageHandler {
     func didFailToSend(_ message: ZMMessage) {
         // nop
     }
-
 }
 
 class ClientRegistrationStatus: NSObject, ClientRegistrationDelegate {
@@ -380,7 +379,6 @@ public class SharingSession {
 }
 
 extension SharingSession: LinkPreviewDetectorType {
-
     public func downloadLinkPreviews(inText text: String, excluding: [NSRange], completion: @escaping ([LinkMetadata]) -> Void) {
         applicationStatusDirectory.linkPreviewDetector.downloadLinkPreviews(inText: text, excluding: excluding, completion: completion)
     }
@@ -390,7 +388,6 @@ extension SharingSession: LinkPreviewDetectorType {
 // MARK: - Helper
 
 fileprivate extension ZMConversationList {
-
     var writeableConversations: [Conversation] {
         return self.filter {
             if let conversation = $0 as? ZMConversation {

--- a/WireShareEngineTests/SharingSessionTests+EncryptionAtRest.swift
+++ b/WireShareEngineTests/SharingSessionTests+EncryptionAtRest.swift
@@ -21,7 +21,7 @@ import LocalAuthentication
 import WireDataModel
 @testable import WireShareEngine
 
-class SharingSessionTests_EncryptionAtRest: BaseSharingSessionTests {
+class SharingSessionTestsEncryptionAtRest: BaseSharingSessionTests {
 
     // MARK: - Life Cycle
 

--- a/WireShareEngineTests/SharingSessionTests.swift
+++ b/WireShareEngineTests/SharingSessionTests.swift
@@ -56,7 +56,8 @@ class SharingSessionTests: BaseSharingSessionTests {
 
     func testThatWriteableNonArchivedConversationsAreReturned() {
         let conversations = Set(sharingSession.writeableNonArchivedConversations.map { $0 as! ZMConversation })
-        XCTAssertEqual(conversations, [activeConversation1, activeConversation2])
+        let activeConversationsSet: Set<ZMConversation?> =  [activeConversation1, activeConversation2]
+        XCTAssertEqual(conversations, activeConversationsSet)
     }
 
     func testThatWritebleArchivedConversationsAreReturned() {

--- a/WireShareEngineTests/SharingSessionTests.swift
+++ b/WireShareEngineTests/SharingSessionTests.swift
@@ -56,7 +56,7 @@ class SharingSessionTests: BaseSharingSessionTests {
 
     func testThatWriteableNonArchivedConversationsAreReturned() {
         let conversations = Set(sharingSession.writeableNonArchivedConversations.map { $0 as! ZMConversation })
-        XCTAssertEqual(conversations, Set(arrayLiteral: activeConversation1, activeConversation2))
+        XCTAssertEqual(conversations, [activeConversation1, activeConversation2])
     }
 
     func testThatWritebleArchivedConversationsAreReturned() {

--- a/WireShareEngineTests/WireShareEngineTestHost/AppDelegate.swift
+++ b/WireShareEngineTests/WireShareEngineTestHost/AppDelegate.swift
@@ -27,15 +27,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.backgroundColor = .red
         window?.makeKeyAndVisible()
-        let vc = UIViewController()
+        let viewController = UIViewController()
         let textView = UITextView()
         textView.text = "This is the test host application for WireShareEngine tests."
-        vc.view.addSubview(textView)
+        viewController.view.addSubview(textView)
         textView.backgroundColor = .green
         textView.textContainerInset = .init(top: 22, left: 22, bottom: 22, right: 22)
         textView.isEditable = false
-        textView.frame = vc.view.frame.insetBy(dx: 22, dy: 44)
-        window?.rootViewController = vc
+        textView.frame = viewController.view.frame.insetBy(dx: 22, dy: 44)
+        window?.rootViewController = viewController
 
         return true
     }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR I fixed warnings for the following SwiftLint rules:

- **Type Name Violation**: Type name should only contain alphanumeric characters: 'SharingSessionTests_EncryptionAtRest' `(type_name)`
- **Shorthand Operator Violation**: Prefer shorthand operators (+=, -=, *=, /=) over doing the operation and assigning. `(shorthand_operator)`
- **Compiler Protocol Init Violation**: The initializers declared in compiler protocol ExpressibleByArrayLiteral shouldn't be called directly. `(compiler_protocol_init)`
- **File Length Violation**: Files should not span too many lines. `(file_length)`

In addition to that I removed a bunch of rules from the list since they don't trigger any warnings and errors by having them enabled. 

- type_body_length
- generic_type_name
- identifier_name
- large_tuple
- unused_setter_value
- notification_center_detachment
- discarded_notification_center_observer
- cyclomatic_complexity
- closure_parameter_position
- statement_position
- weak_delegate
- inclusive_language
- class_delegate_protocol
- legacy_cggeometry_functions
- legacy_constructor
- legacy_hashing
- multiple_closures_with_trailing_closure
- nesting
- function_parameter_count
- xctfail_message
- reduce_boolean

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
