### PR TITLE
feat(mls): setup mls controller for share extension

### DIFF
--- a/Sources/MLS/MLSEncryptionController.swift
+++ b/Sources/MLS/MLSEncryptionController.swift
@@ -1,0 +1,86 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireDataModel
+
+class MLSEncryptionController: MLSControllerProtocol {
+
+    private let coreCrypto: CoreCryptoProtocol
+
+    init(coreCrypto: CoreCryptoProtocol) {
+        self.coreCrypto = coreCrypto
+    }
+
+    func encrypt(message: Bytes, for groupID: MLSGroupID) throws -> WireDataModel.Bytes {
+        return try coreCrypto.wire_encryptMessage(conversationId: groupID.bytes, message: message)
+    }
+
+    func commitPendingProposals(in groupID: MLSGroupID) async throws {
+        // no op
+    }
+
+    func uploadKeyPackagesIfNeeded() {
+        fatalError("not implemented")
+    }
+
+    func createGroup(for groupID: MLSGroupID) throws {
+        fatalError("not implemented")
+    }
+
+    func conversationExists(groupID: MLSGroupID) -> Bool {
+        fatalError("not implemented")
+    }
+
+    func processWelcomeMessage(welcomeMessage: String) throws -> MLSGroupID {
+        fatalError("not implemented")
+    }
+
+    func decrypt(message: String, for groupID: MLSGroupID) throws -> MLSDecryptResult? {
+        fatalError("not implemented")
+    }
+
+    func addMembersToConversation(with users: [MLSUser], for groupID: MLSGroupID) async throws {
+        fatalError("not implemented")
+    }
+
+    func removeMembersFromConversation(with clientIds: [MLSClientID], for groupID: MLSGroupID) async throws {
+        fatalError("not implemented")
+    }
+
+    func registerPendingJoin(_ group: MLSGroupID) {
+        fatalError("not implemented")
+    }
+
+    func performPendingJoins() {
+        fatalError("not implemented")
+    }
+
+    func wipeGroup(_ groupID: MLSGroupID) {
+        fatalError("not implemented")
+    }
+
+    func commitPendingProposals() async throws {
+        fatalError("not implemented")
+    }
+
+    func scheduleCommitPendingProposals(groupID: MLSGroupID, at commitDate: Date) {
+        fatalError("not implemented")
+    }
+
+}

--- a/Sources/MLS/SharingSession+MLS.swift
+++ b/Sources/MLS/SharingSession+MLS.swift
@@ -1,0 +1,46 @@
+//
+// Wire
+// Copyright (C) 2022 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireDataModel
+
+private let logger = ZMSLog(tag: "mls")
+
+extension SharingSession {
+
+    func setupMLSController(
+        sharedContainerURL: URL,
+        syncContext: NSManagedObjectContext,
+        coreCryptoSetup: CoreCryptoSetupClosure
+    ) {
+        syncContext.performAndWait {
+            do {
+                let coreCrypto = try CoreCryptoFactory.coreCrypto(
+                    sharedContainerURL: sharedContainerURL,
+                    syncContext: syncContext,
+                    coreCryptoSetup: coreCryptoSetup
+                )
+                let mlsController = MLSEncryptionController(coreCrypto: coreCrypto)
+                syncContext.setMLSController(mlsController: mlsController)
+            } catch {
+                logger.warn("Failed to setup MLSController: \(String(describing: error))")
+            }
+        }
+    }
+
+}

--- a/WireShareEngine.xcodeproj/project.pbxproj
+++ b/WireShareEngine.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		A958DBBD266576BA00FB8D26 /* WireImages.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A958DBA4266576B900FB8D26 /* WireImages.xcframework */; };
 		A958DBC52665830900FB8D26 /* WireTesting.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A958DBC32665830900FB8D26 /* WireTesting.xcframework */; };
 		A958DBC72665830A00FB8D26 /* OCMock.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A958DBC42665830900FB8D26 /* OCMock.xcframework */; };
+		63172F792902A42700DBECC9 /* SharingSession+MLS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63172F782902A42700DBECC9 /* SharingSession+MLS.swift */; };
+		63172F96290AB47500DBECC9 /* MLSEncryptionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63172F95290AB47500DBECC9 /* MLSEncryptionController.swift */; };
 		BFA18BD41D806050005C281B /* BaseSharingSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA18BD31D806050005C281B /* BaseSharingSessionTests.swift */; };
 		CE7FBFC41E015C5900E1C4C9 /* RequestGeneratorStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7FBFC31E015C5900E1C4C9 /* RequestGeneratorStoreTests.swift */; };
 		CEB50AEC1DF9BADF00211B30 /* OperationLoopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB50AEB1DF9BADF00211B30 /* OperationLoopTests.swift */; };
@@ -107,6 +109,8 @@
 		A958DBA4266576B900FB8D26 /* WireImages.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = WireImages.xcframework; path = Carthage/Build/WireImages.xcframework; sourceTree = "<group>"; };
 		A958DBC32665830900FB8D26 /* WireTesting.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = WireTesting.xcframework; path = Carthage/Build/WireTesting.xcframework; sourceTree = "<group>"; };
 		A958DBC42665830900FB8D26 /* OCMock.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = OCMock.xcframework; path = Carthage/Build/OCMock.xcframework; sourceTree = "<group>"; };
+		63172F782902A42700DBECC9 /* SharingSession+MLS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SharingSession+MLS.swift"; sourceTree = "<group>"; };
+		63172F95290AB47500DBECC9 /* MLSEncryptionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MLSEncryptionController.swift; sourceTree = "<group>"; };
 		A9FF19B027A013780067DC26 /* ios-arm64Simulator.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = "ios-arm64Simulator.xcconfig"; path = "Carthage/Checkouts/wire-ios-system/Resources/Configurations/zmc-config/ios-arm64Simulator.xcconfig"; sourceTree = SOURCE_ROOT; };
 		BFA18BD31D806050005C281B /* BaseSharingSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseSharingSessionTests.swift; sourceTree = "<group>"; };
 		CE7FBFC31E015C5900E1C4C9 /* RequestGeneratorStoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestGeneratorStoreTests.swift; sourceTree = "<group>"; };
@@ -272,6 +276,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		63172F94290AB45100DBECC9 /* MLS */ = {
+			isa = PBXGroup;
+			children = (
+				63172F782902A42700DBECC9 /* SharingSession+MLS.swift */,
+				63172F95290AB47500DBECC9 /* MLSEncryptionController.swift */,
+			);
+			path = MLS;
+			sourceTree = "<group>";
+		};
 		F154EE091F44826400CB8184 /* WireShareEngineTestHost */ = {
 			isa = PBXGroup;
 			children = (
@@ -284,6 +297,7 @@
 		F1DABF961E9B8B6100AD2324 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				63172F94290AB45100DBECC9 /* MLS */,
 				F1DABF971E9B8B6100AD2324 /* AuthenticationStatusProvider.swift */,
 				F1DABF981E9B8B6100AD2324 /* Conversation.swift */,
 				F1DABF991E9B8B6100AD2324 /* OperationLoop.swift */,
@@ -471,6 +485,7 @@
 				F1DABFA31E9B8B6100AD2324 /* Conversation.swift in Sources */,
 				F1DABFAB1E9B8B6100AD2324 /* ZMConversation+Conversation.swift in Sources */,
 				165C55F62551AF1300731CA9 /* SharingSession+EncryptionAtRest.swift in Sources */,
+				63172F96290AB47500DBECC9 /* MLSEncryptionController.swift in Sources */,
 				F1DABFA21E9B8B6100AD2324 /* AuthenticationStatusProvider.swift in Sources */,
 				F1DABFA41E9B8B6100AD2324 /* OperationLoop.swift in Sources */,
 				F1DABFA91E9B8B6100AD2324 /* StrategyFactory.swift in Sources */,
@@ -478,6 +493,7 @@
 				F1DABFAC1E9B8B6100AD2324 /* ZMMessage+Sendable.swift in Sources */,
 				F1DABFA61E9B8B6100AD2324 /* SendableBatchObserver.swift in Sources */,
 				F1DABFA51E9B8B6100AD2324 /* Sendable.swift in Sources */,
+				63172F792902A42700DBECC9 /* SharingSession+MLS.swift in Sources */,
 				F1DABFA71E9B8B6100AD2324 /* SharingSession.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR is about setting up core crypto for the share extension, so that we're able to encrypt message.

### Changes

- Introduced `MLSEncryptionController`. A lightweight version of the `MLSController` that only takes care of encrypting messages
- Added a `setupMLSController` method to set up the controller on the sync context when the sharing session is created

### Dependencies

https://github.com/wireapp/wire-ios-data-model/pull/1425

### Testing

TODO

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
