### PR TITLE
fix: Issue where image wouldn't be send through the share extension - SQSERVICES-1788

### DIFF
--- a/Sources/OperationLoop.swift
+++ b/Sources/OperationLoop.swift
@@ -158,8 +158,9 @@ final class OperationLoop: NSObject, RequestAvailableObserver {
 
     func setupObserver(for context: NSManagedObjectContext, onSave: @escaping SaveClosure) -> NSObjectProtocol {
         return NotificationCenter.default.addObserver(forName: .NSManagedObjectContextDidSave, object: context, queue: callBackQueue) { note in
-            if let insertedObjects = note.userInfo?[NSInsertedObjectsKey] as? Set<NSManagedObject>, let updatedObjects = note.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject> {
-                onSave(note, insertedObjects, updatedObjects)
+            let insertedObjects = note.userInfo?[NSInsertedObjectsKey] as? Set<NSManagedObject> ?? Set<NSManagedObject>()
+            let updatedObjects = note.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject> ?? Set<NSManagedObject>()
+            onSave(note, insertedObjects, updatedObjects)
             }
         }
     }

--- a/Sources/OperationLoop.swift
+++ b/Sources/OperationLoop.swift
@@ -163,7 +163,6 @@ final class OperationLoop: NSObject, RequestAvailableObserver {
             onSave(note, insertedObjects, updatedObjects)
             }
         }
-    }
 
     func merge(changes notification: Notification, intoContext context: NSManagedObjectContext) {
         let moc = notification.object as! NSManagedObjectContext


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/SQSERVICES-1788" title="SQSERVICES-1788" target="_blank"><img alt="Bug" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10803?size=medium" />SQSERVICES-1788</a>  [iOS] Sharing files from outside of the app times out***now error msg changed to you are no longer logged in.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR we fix an issue where we wouldn't be able to send a text and an image using the Share extension

--

The issue was that we weren't able to send an image and text through Share Extension and that was because of the previous implementation of the observer method as well as some changes Apple made with iOS 16 and core data. on iOS 16 and core data Apple filters out empty sets and because of that small subtle change, we couldn't pass the two if-let statements. 

--

As a fix we create insertedObjects and updatedObjects and if they're nil we pass empty sets. With that it fixes the issue

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
